### PR TITLE
Refactor Store into multiple actors to stop operations waiting

### DIFF
--- a/src/main/kotlin/Store.kt
+++ b/src/main/kotlin/Store.kt
@@ -18,130 +18,151 @@ typealias TransactionalLevel = Int
 typealias ID = Int
 typealias Subject = MutableMap<ID, ProducerScope<Any?>>
 
-class Store {
+class Store(
+    scope: CoroutineScope = CoroutineScope(Dispatchers.Unconfined),
+    private val transactionUpdates: MutableMap<TransactionalLevel, BatchUpdates> = mutableMapOf(),
+    private val subscriptions: Tree<Location, Subject> = Tree(),
+    private var transactionLevel: Int = 0,
+    private var count: Int = 0,
+) {
     private sealed interface Intent {
-        data class Set(val route: Route, val value: Any?, val ack: CompletableDeferred<Boolean>) :
-            Intent
-
-        data class Insert(
-            val route: Route,
-            val completedDeferred: CompletableDeferred<Flow<Any?>>
-        ) : Intent
-
-        data class Batch(val updates: BatchUpdates) : Intent
-        data class Transaction1(
-            val ack: CompletableDeferred<Boolean>
-        ) : Intent
-
-        data class Transaction2(
-            val ack: CompletableDeferred<MutableList<Pair<Collection<Location>, Any?>>>
-        ) : Intent
-
-        data class TransactionException(
-            val ack: CompletableDeferred<Boolean>,
-            val exception: Exception
-        ) : Intent
+        data class Set(val route: Route, val value: Any?, val ack: CompletableDeferred<Boolean>) : Intent
+        data class Insert(val route: Route, val completedDeferred: CompletableDeferred<Flow<Any?>>) : Intent
+        data class Batch(val updates: BatchUpdates, val ack: CompletableDeferred<Boolean>) : Intent
+        sealed interface Transaction : Intent {
+            data class IncrementTransactionLevel(val ack: CompletableDeferred<Boolean>) : Transaction
+            data class ProcessTransaction(
+                val ack: CompletableDeferred<Boolean>,
+                val wasSuccess: Boolean,
+            ) : Transaction
+        }
 
         data class Get(val route: Route?, val ack: CompletableDeferred<Any?>) : Intent
         data class TransactionLevel(val ack: CompletableDeferred<Int>) : Intent
     }
 
-    private val scope = CoroutineScope(Dispatchers.Unconfined)
+    private val data: Any? by any()
 
     private val actor = scope.actor<Intent> {
-        val transactionUpdates = mutableMapOf<TransactionalLevel, BatchUpdates>()
-        val subscriptions: Tree<Location, Subject> = Tree()
-        val data: Any? by any()
+        consumeEach {
+            when (it) {
+                is Intent.Batch -> batchActor.send(it)
+                is Intent.Get -> getActor.send(it)
+                is Intent.Insert -> insertActor.send(it)
+                is Intent.Set -> setActor.send(it)
+                is Intent.Transaction -> transactionActor.send(it)
+                is Intent.TransactionLevel -> transactionLevelActor.send(it)
+            }
+        }
+    }
 
-        var transactionLevel = 0
-        var count = 0
-
-        consumeEach { intent ->
-            when (intent) {
-                is Intent.Get -> data.also {
-                    intent.ack.complete(intent.route?.let { data[it] } ?: data)
-                }
-                is Intent.Batch -> {
-                    val routes: MutableSet<Route> = mutableSetOf()
-                    intent.updates.forEach { (route, value) ->
-                        data[route] = value
-                        routes += subscriptions.routes(route)
-                    }
-                    routes.sortedWith { route1, route2 -> route1.compareTo(route2) }
-                        .forEach { route ->
-                            subscriptions[route]?.let {
-                                it.values.forEach { it.send(data[route]) }
-                            }
+    private val transactionActor = scope.actor<Intent.Transaction> {
+        consumeEach {
+            when (it) {
+                is Intent.Transaction.IncrementTransactionLevel -> transactionLevel += 1
+                is Intent.Transaction.ProcessTransaction -> {
+                    if (it.wasSuccess) {
+                        val levelUpdates: MutableList<Pair<Collection<Location>, Any?>> =
+                            transactionUpdates.remove(transactionLevel) ?: mutableListOf()
+                        transactionLevel--
+                        if (transactionLevel > 0) {
+                            transactionUpdates.getOrPut(transactionLevel) { mutableListOf() }
+                                .addAll(levelUpdates)
+                        } else {
+                            batch(levelUpdates)
                         }
-                }
-                is Intent.Insert -> callbackFlow {
-                    val route = intent.route
-                    send(data[route])
-                    count += 1
-                    val id = count
-                    subscriptions[route, mutableMapOf()]?.put(id, this)
-                    awaitClose {
-                        subscriptions[route]?.let {
-                            it.remove(id)
-                            if (it.isEmpty()) {
-                                subscriptions[route] = null as Subject?
-                            }
-                        }
-                    }
-                }.apply {
-                    intent.completedDeferred.complete(this)
-                }
-                is Intent.Transaction1 -> {
-                    transactionLevel += 1
-                    intent.ack.complete(true)
-                }
-                is Intent.Transaction2 -> {
-                    val levelUpdates: MutableList<Pair<Collection<Location>, Any?>> =
-                        transactionUpdates.remove(transactionLevel) ?: mutableListOf()
-                    transactionLevel--
-                    if (transactionLevel > 0) {
-                        transactionUpdates.getOrPut(transactionLevel, { mutableListOf() })
-                            .addAll(levelUpdates)
-                        intent.ack.complete(mutableListOf())
+                        it.ack.complete(true)
                     } else {
-                        intent.ack.complete(levelUpdates)
+                        transactionUpdates.remove(transactionLevel)
+                        transactionLevel -= 1
+                        it.ack.completeExceptionally(IllegalStateException("Transaction failed"))
                     }
-                }
-                is Intent.TransactionException -> {
-                    transactionUpdates.remove(transactionLevel)
-                    transactionLevel -= 1
-                    intent.ack.completeExceptionally(intent.exception)
-                }
-                is Intent.TransactionLevel -> intent.ack.complete(transactionLevel)
-                is Intent.Set -> {
-                    val (route, value, ack) = intent
-                    if (transactionLevel == 0) {
-                        data[route] = value
-                        route.lineage.reversed().forEach { lineage ->
-                            subscriptions[lineage].let { subject ->
-                                subject?.values?.forEach {
-                                    it.send(data[lineage])
-                                }
-                            }
-                        }
-                        subscriptions.getTree(route)?.traverse { subRoute, subject ->
-                            subject?.let {
-                                launch {
-                                    subject.values.forEach {
-                                        it.send(value[subRoute])
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        transactionUpdates.getOrPut(
-                            key = transactionLevel,
-                            defaultValue = { mutableListOf() }
-                        ).add(route to value)
-                    }
-                    ack.complete(true)
                 }
             }
+        }
+    }
+
+    private val transactionLevelActor = scope.actor<Intent.TransactionLevel> {
+        consumeEach {
+            it.ack.complete(transactionLevel)
+        }
+    }
+
+    private val getActor = scope.actor<Intent.Get> {
+        consumeEach { intent ->
+            data.also {
+                intent.ack.complete(intent.route?.let { data[it] } ?: data)
+            }
+        }
+    }
+
+    private val insertActor = scope.actor<Intent.Insert> {
+        consumeEach {
+            callbackFlow {
+                val route = it.route
+                send(data[route])
+                count += 1
+                val id = count
+                subscriptions[route, mutableMapOf()]?.put(id, this)
+                awaitClose {
+                    subscriptions[route]?.let {
+                        it.remove(id)
+                        if (it.isEmpty()) {
+                            subscriptions[route] = null as Subject?
+                        }
+                    }
+                }
+            }.apply {
+                it.completedDeferred.complete(this)
+            }
+        }
+    }
+
+    private val batchActor = scope.actor<Intent.Batch> {
+        consumeEach {
+            val routes: MutableSet<Route> = mutableSetOf()
+            it.updates.forEach { (route, value) ->
+                data[route] = value
+                routes += subscriptions.routes(route)
+            }
+            routes.sortedWith { route1, route2 -> route1.compareTo(route2) }
+                .forEach { route ->
+                    subscriptions[route]?.let {
+                        it.values.forEach { it.send(data[route]) }
+                    }
+                }
+            it.ack.complete(true)
+        }
+    }
+
+    private val setActor = scope.actor<Intent.Set> {
+        consumeEach {
+            val (route, value, ack) = it
+            if (transactionLevel == 0) {
+                data[route] = value
+                route.lineage.reversed().forEach { lineage ->
+                    subscriptions[lineage].let { subject ->
+                        subject?.values?.forEach {
+                            it.send(data[lineage])
+                        }
+                    }
+                }
+                subscriptions.getTree(route)?.traverse { subRoute, subject ->
+                    subject?.let {
+                        launch {
+                            subject.values.forEach {
+                                it.send(value[subRoute])
+                            }
+                        }
+                    }
+                }
+            } else {
+                transactionUpdates.getOrPut(
+                    key = transactionLevel,
+                    defaultValue = { mutableListOf() }
+                ).add(route to value)
+            }
+            ack.complete(true)
         }
     }
 
@@ -157,9 +178,10 @@ class Store {
             actor.send(Intent.Set(route, value, this))
         }.await()
 
-    suspend fun batch(batchUpdates: BatchUpdates) {
-        actor.send(Intent.Batch(batchUpdates))
-    }
+    suspend fun batch(batchUpdates: BatchUpdates): Boolean =
+        CompletableDeferred<Boolean>().apply {
+            actor.send(Intent.Batch(batchUpdates, this))
+        }.await()
 
     suspend fun get(vararg route: Location) = get(route.toList())
     suspend fun get(route: Route? = null): Any? =
@@ -169,20 +191,15 @@ class Store {
 
     suspend fun transaction(updates: suspend Store.() -> Unit) {
         CompletableDeferred<Boolean>().apply {
-            actor.send(Intent.Transaction1(this))
-        }.await()
-        try {
-            updates()
-            CompletableDeferred<MutableList<Pair<Collection<Location>, Any?>>>().apply {
-                actor.send(Intent.Transaction2(this))
-            }.await().also {
-                actor.send(Intent.Batch(it))
+            actor.send(Intent.Transaction.IncrementTransactionLevel(this))
+            val isSuccessful = try {
+                updates()
+                true
+            } catch (exception: Exception) {
+                false
             }
-        } catch (exception: Exception) {
-            CompletableDeferred<Boolean>().apply {
-                actor.send(Intent.TransactionException(this, exception))
-            }.await()
-        }
+            actor.send(Intent.Transaction.ProcessTransaction(this, isSuccessful))
+        }.await()
     }
 
     suspend fun transactionalLevel(): Int =


### PR DESCRIPTION
Operations used to wait on each other, now we have a supreme actor that routes messages to the rest ensuring they are not blocked.

This still doesn't fix calling the same operation within itself though.